### PR TITLE
\smash the hypertarget box to fix issue #27

### DIFF
--- a/enotez.sty
+++ b/enotez.sty
@@ -202,8 +202,10 @@
         \enotezwritemark { \hyperlink {enz.#1} { \enmarkstyle #2 } }
         \bool_if:NT \l__enotez_hyperbackref_bool
           {
-            \box_move_up:nn {1em}
-              { \hbox:n { \hypertarget {enz.#1.backref} { } } }
+            \smash{
+              \box_move_up:nn {1em}
+                { \hbox:n { \hypertarget {enz.#1.backref} { } } }
+            }
           }
       }
       { \enotezwritemark { \enmarkstyle #2 } }


### PR DESCRIPTION
Smash the `hypertarget` box to prevent `backref` option from modifying the line height. There may be a better, more expl3 way to do this. Fixes #27 .