### PR TITLE
Remove use of `\multendnote` commands, deprecated `split-sectioning` demo, broken `split-title` option

### DIFF
--- a/enotez_split_example.tex
+++ b/enotez_split_example.tex
@@ -62,8 +62,8 @@
 
 \section{Test}
 Text\endnote{\kant[1]}. Text\endnote{\kant[2]}. Text\endnote{This time
-with a \textbf{nested}\multendnote{\kant[3];\kant[4]} endnote.}.
-Text\multendnote{\kant[5];\kant[6]}.
+with a \textbf{nested}\endnote{\kant[3]}\endnote{\kant[4]} endnote.}.
+Text\endnote{\kant[5]}\endnote{\kant[6]}.
 
 \begin{figure}[htp]
   \centering
@@ -85,8 +85,8 @@ Text\multendnote{\kant[5];\kant[6]}.
 
 \section{Test}
 Text\endnote{\kant[1]}. Text\endnote{\kant[2]}. Text\endnote{This time
-with a \textbf{nested}\multendnote{\kant[3];\kant[4]} endnote.}.
-Text\multendnote{\kant[5];\kant[6]}.
+with a \textbf{nested}\endnote{\kant[3]}\endnote{\kant[4]} endnote.}.
+Text\endnote{\kant[5]}\endnote{\kant[6]}.
 \begin{figure}[htp]
  \centering
  \includegraphics[width=.4\linewidth]{example-image-a}

--- a/enotez_split_example.tex
+++ b/enotez_split_example.tex
@@ -45,10 +45,10 @@
   split=section,
   list-style=section,
   % reset,
-  backref
+  backref,
 % customize the titles in between, e.g.:
-%   split-sectioning=addsec,
-%   split-title=\par\noindent<name> <ref>:
+%   split-heading=\subsection*{#1},
+%   split-title=\noindent<ref> <name>
 }
 
 \usepackage{fnpct}


### PR DESCRIPTION
Remove use of \multendnote commands to make enotez_split_example.tex work out-of-the-box. Fixes #30